### PR TITLE
Add option to set the interpolation mode used when scaling the preview

### DIFF
--- a/PrintDialogX.Test/MainWindow.xaml.cs
+++ b/PrintDialogX.Test/MainWindow.xaml.cs
@@ -67,6 +67,7 @@ namespace PrintDialogX.Test
             PrintDialogX.PrintDialog.PrintDialog printDialog = new PrintDialogX.PrintDialog.PrintDialog()
             {
                 Owner = this, //Set the owner of the dialog to the current window
+                InterpolationMode = System.Windows.Media.BitmapScalingMode.Linear, //Set the interpolation mode for scaling the preview
                 Title = "Test Print", //Set the title of the dialog
                 Icon = null, //Set the icon of the dialog, where null means to use the default icon
                 Topmost = false, //Don't allow the dialog to appear in the topmost z-order

--- a/PrintDialogX/PrintDialog.cs
+++ b/PrintDialogX/PrintDialog.cs
@@ -20,6 +20,11 @@ namespace PrintDialogX.PrintDialog
         public Window Owner { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the interpolation mode used to scale the preview. (Default: <see cref="System.Windows.Media.BitmapScalingMode.NearestNeighbor"/>)
+        /// </summary>
+        public System.Windows.Media.BitmapScalingMode InterpolationMode { get; set; } = System.Windows.Media.BitmapScalingMode.NearestNeighbor;
+
+        /// <summary>
         /// Gets or sets the title of the dialog.
         /// </summary>
         public string Title { get; set; } = "Print";

--- a/PrintDialogX/PrintPage.xaml.cs
+++ b/PrintDialogX/PrintPage.xaml.cs
@@ -13,6 +13,8 @@ namespace PrintDialogX.Internal
 
         private readonly PrintWindow _owner;
 
+        private readonly System.Windows.Media.BitmapScalingMode _interpolationMode;
+
         private System.Windows.Documents.FixedDocument _previewDocument;
 
         private readonly PrintServer _printServer;
@@ -46,6 +48,8 @@ namespace PrintDialogX.Internal
             Common.DoEvents();
 
             _owner = owner;
+
+            _interpolationMode = dialog.InterpolationMode;
 
             _originalDocument = new List<PrintDialogX.PrintPage>();
             _originalDocument.AddRange(dialog.Document.Pages);
@@ -459,7 +463,7 @@ namespace PrintDialogX.Internal
                     }
 
                     System.Windows.Documents.FixedPage page = new System.Windows.Documents.FixedPage() { Width = document.DocumentPaginator.PageSize.Width, Height = document.DocumentPaginator.PageSize.Height, IsHitTestVisible = false };
-                    System.Windows.Media.RenderOptions.SetBitmapScalingMode(page, System.Windows.Media.BitmapScalingMode.NearestNeighbor);
+                    System.Windows.Media.RenderOptions.SetBitmapScalingMode(page, _interpolationMode);
                     Decorator elementContainer = new Decorator() { Child = element, Width = _originalDocumentSize.Width - _originalDocumentMargin * 2, Height = _originalDocumentSize.Height - _originalDocumentMargin * 2, HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
                     Decorator elementBoundary = new Decorator() { Child = elementContainer, Width = page.Width - documentMargin * 2, Height = page.Height - documentMargin * 2 };
                     if (optionPagesPerSheet.SelectedIndex <= 0)


### PR DESCRIPTION
A recent commit shows to the interpolation mode can be set with a hardcoded explicit set to `NearestNeighbor`. This PR exposes the mode as a setting on `PrintDialog` so that consumers can use different settings to prioritize quality over performance.
<hr />
`NearestNeighbor`:<br />

<img width="161" height="158" alt="image" src="https://github.com/user-attachments/assets/b61f0827-9a7d-48f8-8e50-47477676d93c" />
<img width="347" height="315" alt="image" src="https://github.com/user-attachments/assets/7b34b6a9-c7aa-4e9a-944c-4bfa6abf533d" />
<img width="645" height="494" alt="image" src="https://github.com/user-attachments/assets/c08d0094-db95-4e88-a6c1-ee0c48baded1" />
<hr />
`HighQuality` (`Fant`):<br />

<img width="144" height="101" alt="image" src="https://github.com/user-attachments/assets/42de6295-4d4a-48e6-bc9c-6ea5c5a632a9" />
<img width="299" height="239" alt="image" src="https://github.com/user-attachments/assets/b235a871-dc43-4d43-bdd8-7e01d65ac6ee" />
<img width="615" height="504" alt="image" src="https://github.com/user-attachments/assets/9d4bf476-aada-4a95-81cc-1bcab81f782b" />
