### PR TITLE
Fix Ctrl+MouseWheel zooming of the preview

### DIFF
--- a/PrintDialogX/UserControls/NoKeypadDocumentViewer.cs
+++ b/PrintDialogX/UserControls/NoKeypadDocumentViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Controls;
 using System.Windows.Automation.Peers;
+using System.Reflection;
 
 namespace PrintDialogX.Internal.UserControls
 {
@@ -8,6 +9,26 @@ namespace PrintDialogX.Internal.UserControls
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new FrameworkElementAutomationPeer(this);
+        }
+
+        protected override void OnDocumentChanged()
+        {
+            base.OnDocumentChanged();
+
+            // DocumentViewer has as internal property IsSelectionEnabled. It aggressively sets
+            // it to true every time the document changes. But, when selection is enabled,
+            // Ctrl+MouseWheel zooming has a highly-undesirable side-effect of resetting the
+            // viewport to the top/left of the page every time the zoom changes. This behaviour
+            // only happens when selection is enabled (and thus it has a visible insertion point).
+            // So, we always set it to false in order to keep the viewport offset when zooming.
+            DisableSelection();
+        }
+
+        static PropertyInfo s_IsSelectionEnabled_property = typeof(DocumentViewer).GetProperty("IsSelectionEnabled", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        void DisableSelection()
+        {
+            s_IsSelectionEnabled_property?.SetValue(this, false);
         }
     }
 }


### PR DESCRIPTION
The built-in functionality of `DocumentViewer` allows you to scale the document preview as a whole, zoom in and out, using Ctrl+MouseWheel. But, every time the zoom level changes, the preview snaps back to the top/left of the page. This effectively makes it impractical to zoom in on a specific feature.

I spent some time digging into the underlying cause of this behaviour in the WPF reference source, and have tracked it down to the following, buried deep within WPF internal code:

```
        private object SetScaleDelegate(object scale)
        {
            if (!(scale is double))
            {
                return null;
            }

            double newScale = (double)scale;
            _documentLayout.ViewMode = ViewMode.Zoom;

            //Get the current visible selection, if any.
            //The results of this will determine how we handle the
            //zoom operation.
            ITextPointer selection = GetVisibleSelection();

            if (selection != null)
            {
                //The visible-IP case:
                //First, we find out what page the IP is on:
                int selectionPage = GetPageNumberForVisibleSelection(selection);

                //Then we scale the document:
                UpdateLayoutScale(newScale);

                //Now we ensure that the selection page is still
                //visible:
                MakePageVisible(selectionPage);

                //The rest of this process is done asynchronously --
                //We wait for LayoutUpdated (which happens after layout
                //but before rendering) and then make the IP visible.
                //This will cause the IP to be centered without any
                //visible flicker.

                //Attach a LayoutUpdated handler.
                LayoutUpdated += new EventHandler(OnZoomLayoutUpdated);
            }
            else
            {
                //The non-visible-IP case:
                //This is considerably easier.  The expected behavior is that
                //we zoom in on the upper-left corner of the currently-visible
                //content.  This is accomplished by scaling the Vertical and
                //Horizontal offsets in tandem with the document scale which will
                //put us approximately where we were before.

                //Scale the document:
                UpdateLayoutScale(newScale);
            }

            return null;
        }
```
(`src\Microsoft.DotNet.Wpf\src\PresentationFramework\MS\Internal\documents\DocumentGrid.cs`)

Specifically, it is written primarily from the focus of a highly-zoomed-out grid showing multiple pages, and if it thinks it has an active selection, it ensures that the page containing that selection is visible at the new zoom level:

```
                //The visible-IP case:
                //First, we find out what page the IP is on:
                int selectionPage = GetPageNumberForVisibleSelection(selection);

                //Then we scale the document:
                UpdateLayoutScale(newScale);

                //Now we ensure that the selection page is still
                //visible:
                MakePageVisible(selectionPage);
```

But, this has the unintended side-effect of moving the viewport to the top/left of that page.

I have discovered experimentally that forcefully disabling `IsSelectionEnabled`, as was proposed in #9, prevents it from thinking that there is a visible insertion point, which prevents the above code from running. Instead, it runs this branch:

```
                //The non-visible-IP case:
                //This is considerably easier.  The expected behavior is that
                //we zoom in on the upper-left corner of the currently-visible
                //content.  This is accomplished by scaling the Vertical and
                //Horizontal offsets in tandem with the document scale which will
                //put us approximately where we were before.

                //Scale the document:
                UpdateLayoutScale(newScale);
```

And now the viewport doesn't snap to the top/left of the page. (It could do better; the origin for the scaling isn't the centre of the viewport but its top-left. But, that's still heckin' better than resetting to (0, 0) every time!)

This PR reintroduces a little bit of the code from #9, not as a user-selectable option, but simply to _always_ set `IsSelectionEnabled` to false, fixing the problem with Ctrl+MouseWheel zooming.